### PR TITLE
Improve the installation of Bulma and the theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,10 @@
         "@fortawesome/free-brands-svg-icons": "^5.15.1",
         "@fortawesome/free-solid-svg-icons": "^5.15.1",
         "@fortawesome/react-fontawesome": "^0.1.13",
+        "bulma": "^0.9.1",
         "bulmaswatch": "^0.8.1",
         "react": "^17.0.1",
-        "react-bulma-components": "^3.4.0",
+        "react-bulma-components": "3.4.0",
         "react-dom": "^17.0.1"
       },
       "devDependencies": {
@@ -5131,6 +5132,11 @@
       "resolved": "https://registry.npmjs.org/buffer-json/-/buffer-json-2.0.0.tgz",
       "integrity": "sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==",
       "dev": true
+    },
+    "node_modules/bulma": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.1.tgz",
+      "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA=="
     },
     "node_modules/bulmaswatch": {
       "version": "0.8.1",
@@ -22518,6 +22524,11 @@
       "resolved": "https://registry.npmjs.org/buffer-json/-/buffer-json-2.0.0.tgz",
       "integrity": "sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==",
       "dev": true
+    },
+    "bulma": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.1.tgz",
+      "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA=="
     },
     "bulmaswatch": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.13",
+    "bulma": "^0.9.1",
     "bulmaswatch": "^0.8.1",
     "react": "^17.0.1",
     "react-bulma-components": "^3.4.0",

--- a/src/components/__tests__/image-box-section.test.tsx
+++ b/src/components/__tests__/image-box-section.test.tsx
@@ -1,17 +1,16 @@
 import "@testing-library/jest-dom";
 
+import { Box, Image } from "react-bulma-components";
+import React, { ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 
-import Box from "react-bulma-components/lib/components/box";
-import Image from "react-bulma-components/lib/components/image";
 import ImageBoxSection from "../image-box-section";
-import React from "react";
 import faker from "faker";
 
 let text: string;
 let imageSrc: string;
-let box: Box;
-let image: Image;
+let box: ReactElement<Box>;
+let image: ReactElement<Image>;
 
 beforeAll(() => {
     text = faker.lorem.paragraph();

--- a/src/components/button-link.tsx
+++ b/src/components/button-link.tsx
@@ -11,7 +11,7 @@ interface ButtonLinkProps {
 
 export default function AboutMe({ url, text, icon }: ButtonLinkProps): ReactElement {
     return (
-        <a href={url} className="button is-link" target="_blank" rel="noreferrer">
+        <a href={url} className="button is-link is-info" target="_blank" rel="noreferrer">
             <span className="icon is-small">
                 <FontAwesomeIcon icon={icon} />
             </span>

--- a/src/components/image-box-section.tsx
+++ b/src/components/image-box-section.tsx
@@ -1,22 +1,17 @@
+import { Box, Columns, Content, Image, Section } from "react-bulma-components";
 import React, { ReactElement } from "react";
-
-import Box from "react-bulma-components/lib/components/box";
-import Columns from "react-bulma-components/lib/components/columns";
-import Content from "react-bulma-components/lib/components/content";
-import Image from "react-bulma-components/lib/components/image";
-import Section from "react-bulma-components/lib/components/section";
 
 interface ImageBoxSectionProps {
     isImageOnLeft?: boolean;
-    image: Image;
-    box: Box;
+    image: ReactElement<Image>;
+    box: ReactElement<Box>;
 }
 
-function renderImageAndBox(image: Image, box: Box, isImageOnLeft?: boolean): ReactElement {
+function renderImageAndBox(image: ReactElement<Image>, box: ReactElement<Box>, isImageOnLeft?: boolean): ReactElement {
     const imageColumnSize = "one-third";
 
     return (
-        <React.Fragment>
+        <Columns>
             {isImageOnLeft &&
                 <Columns.Column size={imageColumnSize}>
                     <Content>
@@ -32,16 +27,14 @@ function renderImageAndBox(image: Image, box: Box, isImageOnLeft?: boolean): Rea
                         {image}
                     </Content>
                 </Columns.Column>}
-        </React.Fragment>
+        </Columns>
     );
 }
 
 export default function ImageBoxSection({ isImageOnLeft, image, box }: ImageBoxSectionProps): ReactElement {
     return (
         <Section>
-            <Columns>
-                {renderImageAndBox(image, box, isImageOnLeft)}
-            </Columns>
+            {renderImageAndBox(image, box, isImageOnLeft)}
         </Section>
     );
 }

--- a/src/sass/_variables.sass
+++ b/src/sass/_variables.sass
@@ -1,3 +1,0 @@
-// Required for react-bulma-components v3.4.0
-
-$button-focus-border-color: #fff

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -1,5 +1,3 @@
-@import "variables";
-
-@import "~bulmaswatch/solar/variables.scss";
-@import "~react-bulma-components/src/index.sass";
-@import "~bulmaswatch/solar/overrides.scss";
+@import "bulmaswatch/solar/variables";
+@import "bulma";
+@import "bulmaswatch/solar/overrides";

--- a/src/sections/about-me.tsx
+++ b/src/sections/about-me.tsx
@@ -1,12 +1,8 @@
+import { Box, Button, Content, Heading, Image } from "react-bulma-components";
 import React, { ReactElement } from "react";
 
-import Box from "react-bulma-components/lib/components/box";
-import Button from "react-bulma-components/lib/components/button";
 import ButtonLink from "../components/button-link";
-import Content from "react-bulma-components/lib/components/content";
 import DrewCartoonNoBackground from "../images/DrewCartoonNoBackground.png";
-import Heading from "react-bulma-components/lib/components/heading";
-import Image from "react-bulma-components/lib/components/image";
 import ImageBoxSection from "../components/image-box-section";
 
 interface AboutMeProps {


### PR DESCRIPTION
This simplifies how Bulma is wired up and imported into components.  Bulma doesn't natively support TypeScript yet (will soon with the pending 4.0 release!) so there is more room for improvement here in the near future.  This should makes things a bit cleaner and maintainable.  For instance, I was able to remove the compulsory `_variables.sass` file that it was dependent on previously.