### PR TITLE
Fix bug on mobile that made the layout wonky

### DIFF
--- a/src/components/__tests__/__snapshots__/wave-background-section.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/wave-background-section.test.tsx.snap
@@ -1,7 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders a wave background section 1`] = `
-<section
-  className="about-me-center-content"
-/>
+<div>
+  <section
+    className="hero make-transparent is-fullheight"
+  >
+    <div
+      className="hero-body"
+    >
+      <div
+        className="container"
+      />
+    </div>
+  </section>
+</div>
 `;

--- a/src/components/wave-background-section.tsx
+++ b/src/components/wave-background-section.tsx
@@ -1,5 +1,6 @@
 import * as THREE from "three";
 
+import { Container, Hero } from "react-bulma-components";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 
 import WAVES from "vanta/dist/vanta.waves.min";
@@ -37,8 +38,14 @@ export default function WaveBackgroundSection({ ...props }: WaveBackgroundSectio
     }, [vantaEffect]);
 
     return (
-        <section id={props.id} className="about-me-center-content" ref={sectionRef}>
-            {props.children}
-        </section>
+        <div ref={sectionRef}>
+            <Hero size="fullheight" className="make-transparent">
+                <Hero.Body>
+                    <Container>
+                        {props.children}
+                    </Container>
+                </Hero.Body>
+            </Hero>
+        </div>
     );
 }

--- a/src/sass/base/_styling.scss
+++ b/src/sass/base/_styling.scss
@@ -1,0 +1,3 @@
+.make-transparent {
+    background: transparent;
+}

--- a/src/sass/components/_sections.scss
+++ b/src/sass/components/_sections.scss
@@ -1,7 +1,0 @@
-.about-me-center-content {
-    height: 100vh;  
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 0% 5% 0% 5%;
-}

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -4,4 +4,4 @@
 
 @import "layout/sticky_footer";
 
-@import "components/sections";
+@import "base/styling";


### PR DESCRIPTION
Viewing the site on mobile caused an issue where sections were getting chopped over and/or overlapping.  Using a `Hero` component to define the section has built-in support for making a section full-width and full-height while keeping the content centered.  This was what I was originally trying to accomplish in my previous attempt.  This fix is nice because it's more declarative in what I'm trying to do and simpler.

Before:

<img src="https://user-images.githubusercontent.com/15161181/103223531-72318480-48f4-11eb-8020-bb33674d7516.png" width="250">

After:

<img src="https://user-images.githubusercontent.com/15161181/103223963-14516c80-48f5-11eb-894b-a157c0644718.png" width="250">