### PR TITLE
Fix for hamburger menu not working on mobile

### DIFF
--- a/src/components/navbar/__tests__/__snapshots__/navbar-link.test.tsx.snap
+++ b/src/components/navbar/__tests__/__snapshots__/navbar-link.test.tsx.snap
@@ -4,5 +4,6 @@ exports[`creates a link for the navbar 1`] = `
 <a
   className="navbar-item"
   onClick={[Function]}
+  role="menuLink"
 />
 `;

--- a/src/components/navbar/__tests__/__snapshots__/navbar.test.tsx.snap
+++ b/src/components/navbar/__tests__/__snapshots__/navbar.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`creates the navbar 1`] = `
     <div
       className="navbar-burger"
       onClick={[Function]}
-      role="button"
+      role="hamburgerButton"
       style={
         Object {
           "outline": "none",
@@ -35,6 +35,7 @@ exports[`creates the navbar 1`] = `
   </div>
   <div
     className="navbar-menu"
+    role="menu"
   >
     <div
       className="navbar-start"
@@ -42,12 +43,14 @@ exports[`creates the navbar 1`] = `
       <a
         className="navbar-item"
         onClick={[Function]}
+        role="menuLink"
       >
         About Me
       </a>
       <a
         className="navbar-item"
         onClick={[Function]}
+        role="menuLink"
       >
         History
       </a>

--- a/src/components/navbar/__tests__/navbar-link.test.tsx
+++ b/src/components/navbar/__tests__/navbar-link.test.tsx
@@ -1,12 +1,34 @@
 import "@testing-library/jest-dom";
 
+import { render, screen } from "@testing-library/react";
+
 import NavbarLink from "../navbar-link";
 import React from "react";
 import faker from "faker";
 import renderer from "react-test-renderer";
+import userEvent from "@testing-library/user-event";
 
 it("creates a link for the navbar", () => {
-    const navbarLink = renderer.create(<NavbarLink to="section" offset={faker.random.number()} />).toJSON();
+    const navbarLink = renderer.create(<NavbarLink to="section" onClick={jest.fn()} offset={faker.random.number()} />).toJSON();
 
     expect(navbarLink).toMatchSnapshot();
+});
+
+it("calls the onClick callback when link is clicked", () => {
+    const mockOnClickCallback = jest.fn();
+    const linkText = faker.random.word();
+    const section = faker.random.word();
+
+    render(
+        <React.Fragment>
+            <NavbarLink to={section} onClick={mockOnClickCallback}>{linkText}</NavbarLink>
+            <div id={section} />
+        </React.Fragment>
+    );
+
+    const link = screen.getByText(linkText);
+
+    userEvent.click(link);
+
+    expect(mockOnClickCallback).toHaveBeenCalledTimes(1);
 });

--- a/src/components/navbar/__tests__/navbar.test.tsx
+++ b/src/components/navbar/__tests__/navbar.test.tsx
@@ -27,3 +27,75 @@ it("calls function to scroll to top when the home link is clicked", () => {
 
     expect(mockScrollToTop).toHaveBeenCalledTimes(1);
 });
+
+function getHamburgerMenuButton(): HTMLElement {
+    return screen.getByRole("hamburgerButton");
+}
+
+function getMenu(): HTMLElement {
+    return screen.getByRole("menu");
+}
+
+describe("when clicking the hamburger menu button", () => {
+    it(`adds "is-active" class to hamburger menu button`, () => {
+        render(<Navbar />);
+
+        const hamburgerMenuButton = getHamburgerMenuButton();
+
+        expect(hamburgerMenuButton).not.toHaveClass("is-active");
+
+        userEvent.click(hamburgerMenuButton);
+
+        expect(hamburgerMenuButton).toHaveClass("is-active");
+    });
+
+    it(`adds "is-active" class to menu`, () => {
+        render(<Navbar />);
+
+        const hamburgerMenuButton = getHamburgerMenuButton();
+        const menu = getMenu();
+
+        expect(menu).not.toHaveClass("is-active");
+
+        userEvent.click(hamburgerMenuButton);
+
+        expect(menu).toHaveClass("is-active");
+    });
+});
+
+describe("when clicking menu link in open hamburger menu", () => {
+    function getRandomMenuLink(): HTMLElement {
+        const menuLinks = screen.getAllByRole("menuLink");
+
+        return menuLinks[Math.floor(Math.random() * menuLinks.length)];
+    }
+
+    it(`removes "is-active" class from hamburger menu button`, () => {
+        render(<Navbar />);
+
+        const hamburgerMenuButton = getHamburgerMenuButton();
+
+        userEvent.click(hamburgerMenuButton);
+
+        expect(hamburgerMenuButton).toHaveClass("is-active");
+
+        userEvent.click(getRandomMenuLink());
+
+        expect(hamburgerMenuButton).not.toHaveClass("is-active");
+    });
+
+    it(`removes "is-active" class from menu`, () => {
+        render(<Navbar />);
+
+        const hamburgerMenuButton = getHamburgerMenuButton();
+        const menu = getMenu();
+
+        userEvent.click(hamburgerMenuButton);
+
+        expect(menu).toHaveClass("is-active");
+
+        userEvent.click(getRandomMenuLink());
+
+        expect(menu).not.toHaveClass("is-active");
+    });
+});

--- a/src/components/navbar/navbar-link.tsx
+++ b/src/components/navbar/navbar-link.tsx
@@ -4,14 +4,16 @@ import { Link } from "react-scroll";
 
 interface NavbarLinkProps extends React.HTMLAttributes<HTMLAnchorElement> {
     to: string;
+    onClick: () => void;
     offset?: number;
 }
 
-export default function NavbarLink({ to, offset, ...props }: NavbarLinkProps): ReactElement {
+export default function NavbarLink({ to, offset, onClick, ...props }: NavbarLinkProps): ReactElement {
     const scrollDurationMs = 800;
 
     return (
         <Link
+            onClick={onClick}
             className="navbar-item"
             activeClass="active"
             to={to}
@@ -19,6 +21,7 @@ export default function NavbarLink({ to, offset, ...props }: NavbarLinkProps): R
             smooth={true}
             duration={scrollDurationMs}
             offset={offset}
+            role="menuLink"
         >
             {props.children}
         </Link>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 
 import { Navbar as BulmaNavbar } from "react-bulma-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -9,18 +9,28 @@ import { useOffset } from "../../hooks/useOffset";
 export default function Navbar(): ReactElement {
     const { offsetRef, offset } = useOffset();
 
+    const [isActive, setIsActive] = useState(false);
+
+    function closeMenu(): void {
+        setIsActive(false);
+    }
+
     return (
         <BulmaNavbar fixed={"top"} domRef={offsetRef}>
             <BulmaNavbar.Brand>
                 <BulmaNavbar.Item role="home" renderAs="a" onClick={(): void => animateScroll.scrollToTop()}>
                     <FontAwesomeIcon icon={["fas", "code"]} size="2x" />
                 </BulmaNavbar.Item>
-                <BulmaNavbar.Burger />
+                <BulmaNavbar.Burger
+                    role="hamburgerButton"
+                    onClick={(): void => setIsActive(!isActive)}
+                    className={`${isActive ? "is-active" : ""}`}
+                />
             </BulmaNavbar.Brand>
-            <BulmaNavbar.Menu>
+            <BulmaNavbar.Menu role="menu" className={`${isActive ? "is-active" : ""}`}>
                 <BulmaNavbar.Container>
-                    <NavbarLink to="aboutMe" offset={offset}>About Me</NavbarLink>
-                    <NavbarLink to="history" offset={offset}>History</NavbarLink>
+                    <NavbarLink onClick={closeMenu} to="aboutMe" offset={offset}>About Me</NavbarLink>
+                    <NavbarLink onClick={closeMenu} to="history" offset={offset}>History</NavbarLink>
                 </BulmaNavbar.Container>
             </BulmaNavbar.Menu>
         </BulmaNavbar>


### PR DESCRIPTION
Bulma doesn't ship with _any_ JS, so clicking on the hamburger menu did nothing.  This adds support to add the `is-active` class to the appropriate elements when the hamburger menu is clicked on.  Likewise, it'll remove the `is-active` class when the "X" is clicked on or when an item in the menu is clicked on so that the menu will collapse.

Closes #41 