### PR TITLE
Add permissions to GitHub Actions for writing to PRs

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -6,6 +6,9 @@ on:
     branches: [master]
 jobs:
   test:
+    permissions:
+      checks: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository


### PR DESCRIPTION
Recent PR builds have been failing because of `"Resource not accessible by integration"` errors. This should give the correct permissions to the job to publish to the PR. This seems to be due to recent changes GitHub has made to GitHub Actions.